### PR TITLE
Modify formatting of console commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ Anna koneen asentaa riippuvuudet, tämän jälkeen siirry hakemistoon "src", sov
 >**flask run**
 
 Sovellus käynnistyy osoitteessa http://127.0.0.1:5000
+

--- a/README.md
+++ b/README.md
@@ -23,17 +23,19 @@ Github-actions on hyväksynyt koodin.
 
 Kloonaa repositorio koneellesi käskyllä
 
->**git clone https://github.com/MatiasSinisalo/ohtu_mini_projekti**
+```console
+git clone https://github.com/MatiasSinisalo/ohtu_mini_projekti
+```
 
 Tämän jälkeen siirry kloonin juurihakemistoon (kansio, josssa on tiedosto "app.py") ja anna käsky 
-
->**poetry install**
+```console
+poetry install
+```
 
 Anna koneen asentaa riippuvuudet, tämän jälkeen siirry hakemistoon "src", sovellus käynnistyy käskyillä
-
->**poetry shell**
->
->**flask run**
+```console
+poetry shell
+flask run
+```
 
 Sovellus käynnistyy osoitteessa http://127.0.0.1:5000
-


### PR DESCRIPTION
Week6 Exercise6
With this console-formatting it would be easier to copy the commands by just clicking the copy button that will appear when rendered in markdown.